### PR TITLE
Fix error name typo

### DIFF
--- a/dbt/adapters/iris/connections.py
+++ b/dbt/adapters/iris/connections.py
@@ -104,7 +104,7 @@ class IRISConnectionManager(SQLConnectionManager):
             connection.handle = dbapi.connect(**kwargs)
             connection.state = "open"
         except Exception as e:
-            raise dbt.exceptions.FailedToConnectException(str(e))
+            raise dbt.exceptions.FailedToConnectError(str(e))
 
         return connection
 


### PR DESCRIPTION
a customer ran into the following error connecting:

```
module 'dbt.exceptions' has no attribute 'FailedToConnectException'
```

I noticed this should probably have been `FailedToConnectError` (cf https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/exceptions.py) and is hiding the true connection error.

Tests and code checks workflow passed fine

CC @JacomienSU